### PR TITLE
Buffer zeroing

### DIFF
--- a/src/picasso_global.h
+++ b/src/picasso_global.h
@@ -11,12 +11,22 @@
 #include "math_type.h"
 #include "data_vector.h"
 #include "fixedopt.h"
+#include <string.h>
 
 #include "picasso.h"
 
+inline void* ZeroBufferAlloc(size_t bytes) {
+	void *buffer = mem_malloc(bytes);
+    return buffer?memset(buffer, 0, bytes):NULL;
+}
+inline void* ZeroBuffersAlloc(size_t num, size_t size) {
+	void *buffer = mem_calloc(num, size);
+    return buffer?memset(buffer, 0, bytes):NULL;
+}
+
 //this can be replace by hw buffer!
-#define BufferAlloc(n)         mem_malloc(n)
-#define BuffersAlloc(n, s)     mem_calloc(n, s)
+#define BufferAlloc(n)         ZeroBufferAlloc(n)
+#define BuffersAlloc(n, s)     ZeroBuffersAlloc(n, s)
 #define BufferFree(p)          mem_free(p)
 #define BufferCopy(d, s, n)    mem_copy(d, s, n)
 

--- a/src/picasso_global.h
+++ b/src/picasso_global.h
@@ -16,12 +16,12 @@
 #include "picasso.h"
 
 inline void* ZeroBufferAlloc(size_t bytes) {
-	void *buffer = mem_malloc(bytes);
+    void *buffer = mem_malloc(bytes);
     return buffer?memset(buffer, 0, bytes):NULL;
 }
 inline void* ZeroBuffersAlloc(size_t num, size_t size) {
-	void *buffer = mem_calloc(num, size);
-    return buffer?memset(buffer, 0, bytes):NULL;
+    void *buffer = mem_calloc(num, size);
+    return buffer?memset(buffer, 0, size*num):NULL;
 }
 
 //this can be replace by hw buffer!


### PR DESCRIPTION
### 修改描述
修复`BufferAlloc`及`BuffersAlloc`未清零问题。
使用未清零的 `Buffer`会导致 `ps_canvas_create` 行为异常（预期外的底色）。
### 相关截图
![修复前_1](https://user-images.githubusercontent.com/19519128/54875702-9f5b2400-4e3e-11e9-904d-b2f95ab03cf8.PNG) ![修复前_2](https://user-images.githubusercontent.com/19519128/54875729-24ded400-4e3f-11e9-829c-b5a722d8683d.PNG) 
### 预期及修复截图
![修复后_1](https://user-images.githubusercontent.com/19519128/54875747-5eafda80-4e3f-11e9-9f49-66690c9070f0.PNG) ![修复后_2](https://user-images.githubusercontent.com/19519128/54875748-62dbf800-4e3f-11e9-800d-2ef2ce2faf81.PNG)


